### PR TITLE
code review for profiles-map branch

### DIFF
--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -5,7 +5,7 @@ export function createMapper<T extends Profile>(profiles: T[]): Mapper<T> {
 
   const profileMap = buildProfilesMap(profiles)
 
-  function findProfile(sourceKey: T['sourceKey'], destinationKey: T['destinationKey']): Profile['map'] {
+  function findProfile(sourceKey: T['sourceKey'], destinationKey: T['destinationKey']): Profile {
     const key: ProfileKey<T> = `${sourceKey}-${destinationKey}`
     const profile = profileMap.get(key)
 
@@ -20,23 +20,23 @@ export function createMapper<T extends Profile>(profiles: T[]): Mapper<T> {
     map: (sourceKey, source, destinationKey) => {
       const profile = findProfile(sourceKey, destinationKey)
 
-      return profile(source)
+      return profile.map(source)
     },
     mapMany: (sourceKey, sourceArray, destinationKey) => {
       const profile = findProfile(sourceKey, destinationKey)
 
-      return sourceArray.map(source => profile(source))
+      return sourceArray.map(source => profile.map(source))
     },
   }
 
   return mapper
 }
 
-function buildProfilesMap<T extends Profile>(profiles: T[]): Map<ProfileKey<T>, Profile['map']> {
-  const map: Map<ProfileKey<T>, Profile['map']> = new Map()
+function buildProfilesMap<T extends Profile>(profiles: T[]): Map<ProfileKey<T>, Profile> {
+  const map: Map<ProfileKey<T>, Profile> = new Map()
 
   for (const profile of profiles) {
-    map.set(`${profile.sourceKey}-${profile.destinationKey}`, profile.map)
+    map.set(`${profile.sourceKey}-${profile.destinationKey}`, profile)
   }
 
   return map

--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -3,37 +3,37 @@ import { Mapper, Profile, ProfileKey } from '@/types'
 
 export function createMapper<T extends Profile>(profiles: T[]): Mapper<T> {
 
-  const mappers = buildProfilesMap(profiles)
+  const profileMap = buildProfilesMap(profiles)
 
-  function getMapper(sourceKey: string, destinationKey: string): Profile['map'] {
-    const key: ProfileKey = `${sourceKey}-${destinationKey}`
-    const mapper = mappers.get(key)
+  function findProfile(sourceKey: T['sourceKey'], destinationKey: T['destinationKey']): Profile['map'] {
+    const key: ProfileKey<T> = `${sourceKey}-${destinationKey}`
+    const profile = profileMap.get(key)
 
-    if (!mapper) {
+    if (!profile) {
       throw new ProfileNotFoundError(sourceKey, destinationKey)
     }
 
-    return mapper
+    return profile
   }
 
   const mapper: Mapper<T> = {
     map: (sourceKey, source, destinationKey) => {
-      const mapper = getMapper(sourceKey, destinationKey)
+      const profile = findProfile(sourceKey, destinationKey)
 
-      return mapper(source)
+      return profile(source)
     },
     mapMany: (sourceKey, sourceArray, destinationKey) => {
-      const mapper = getMapper(sourceKey, destinationKey)
+      const profile = findProfile(sourceKey, destinationKey)
 
-      return sourceArray.map(source => mapper(source))
+      return sourceArray.map(source => profile(source))
     },
   }
 
   return mapper
 }
 
-function buildProfilesMap<T extends Profile>(profiles: T[]): Map<ProfileKey, Profile['map']> {
-  const map: Map<ProfileKey, Profile['map']> = new Map()
+function buildProfilesMap<T extends Profile>(profiles: T[]): Map<ProfileKey<T>, Profile['map']> {
+  const map: Map<ProfileKey<T>, Profile['map']> = new Map()
 
   for (const profile of profiles) {
     map.set(`${profile.sourceKey}-${profile.destinationKey}`, profile.map)

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -5,7 +5,7 @@ export interface Profile<TSourceKey extends string = string, TSource = any, TDes
   map: (source: TSource) => TDestination,
 }
 
-export type ProfileKey = `${string}-${string}`
+export type ProfileKey<T extends Profile> = `${T['sourceKey']}-${T['destinationKey']}`
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ExtractSourceKeys<TProfile> = TProfile extends Profile<infer TSourceKey, any, any> ? TSourceKey : never


### PR DESCRIPTION
there is no significant change here, mostly naming changes

`mappers` => `profileMap`
`getMapper` => `findProfile`

this PR also retains the narrowed type for source/destination key. I don't see any tangible benefit to doing this but I like the fact that we have access to this narrowed type and not widening it to just `string`, could have some downstream benefits in the future?