### PR TITLE
wrap exceptions thrown in profile.map calls

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -14,6 +14,10 @@ Anytime `loadProfiles` is called with an import that includes anything that does
 - Make sure your only exporting profiles from within map files
 - Make sure each profile uses `as const satisfies Profile`
 
+## ProfileMappingError
+
+When the mapper is executing `map` function on a given profile, it wraps the call in a try catch. If that function throws an exception for any reason it is wrapped in a `ProfileMappingError`. This provides additional context to the end application where an error is taking place and inside of which specific profile to investigate.
+
 ## Missing types or source type never
 
 If you hover `mapper.map` and see

--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -1,4 +1,5 @@
 import { Mapper, Profile, ProfileKey, RegisteredProfile, RegisteredProfiles, ProfileNotFoundError } from '@/types'
+import { ProfileMappingError } from '@/types/profileMappingError'
 import { asArray } from '@/utilities'
 
 export function createMapper(): Mapper<RegisteredProfiles> {
@@ -41,7 +42,11 @@ export function createMapper(): Mapper<RegisteredProfiles> {
   const map: Mapper<RegisteredProfiles>['map'] = (sourceKey, source, destinationKey) => {
     const profile = getProfile(sourceKey, destinationKey)
 
-    return profile.map(source)
+    try {
+      return profile.map(source)
+    } catch (exception) {
+      throw new ProfileMappingError(profile, { cause: exception })
+    }
   }
 
   const mapMany: Mapper<RegisteredProfiles>['mapMany'] = (sourceKey, sourceArray, destinationKey) => {

--- a/src/createmapper.spec.ts
+++ b/src/createmapper.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import mapper from '@/index'
 import { Profile } from '@/types'
+import { ProfileMappingError } from '@/types/profileMappingError'
 
 const stringToBoolean = {
   sourceKey: 'string',
@@ -32,4 +33,20 @@ test('register works with single profile', () => {
   mapper.register(singleProfile)
 
   expect(mapper.has('foo', 'bar')).toBe(true)
+})
+
+test('when map function throws exception, wraps in ProfileMappingError', () => {
+  const singleProfile = {
+    sourceKey: 'foo',
+    destinationKey: 'bar',
+    map: () => {
+      throw 'not implemented'
+    },
+  } as const satisfies Profile
+
+  mapper.register(singleProfile)
+
+  const action: () => void = () => mapper.map('foo', null, 'bar')
+
+  expect(action).toThrow(ProfileMappingError)
 })

--- a/src/types/profileMappingError.ts
+++ b/src/types/profileMappingError.ts
@@ -1,0 +1,7 @@
+import { Profile } from '@/types/profile'
+
+export class ProfileMappingError extends Error {
+  public constructor(profile: Profile, options?: ErrorOptions) {
+    super(`Failed to Execute map for source "${profile.sourceKey}" and destination "${profile.destinationKey}"`, options)
+  }
+}


### PR DESCRIPTION
this gives end developers the opportunity to setup logging to watch for specific `ProfileMappingError`, which provides more context when a model might change without Typescript being updated